### PR TITLE
feat: repurpose demo into User Management dashboard with `/users` route

### DIFF
--- a/react-layout-router-demo/src/config/router.js
+++ b/react-layout-router-demo/src/config/router.js
@@ -80,6 +80,7 @@ export default class RouterPage extends Component {
                 <Route path="/" component={App}>
                     <IndexRoute component={HomePage} />
                     <Route path="/tools" component={ToolsPage} />
+                    <Route path="/users" component={ToolsPage} />
                     <Route path="/about" component={AboutPage} />
                     <Route path="/other" component={OtherPage} />
                 </Route>

--- a/react-layout-router-demo/src/index.tmpl.html
+++ b/react-layout-router-demo/src/index.tmpl.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <title>Gfresh Routes</title>
+    <title>User Admin Hub</title>
 </head>
 
 <body>

--- a/react-layout-router-demo/src/pages/about.page.js
+++ b/react-layout-router-demo/src/pages/about.page.js
@@ -1,25 +1,13 @@
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import {
     firebaseConnect,
-    isLoaded,
-    isEmpty,
     dataToJS,
-    pathToJS,
 } from 'react-redux-firebase';
 import { Link } from 'react-router';
 
-/**
- * import libs: antd, material
- */
-import Layout from './layout';
 import LayoutInner from './layout-inner';
-/**
- * initialize a Page Component named HomePage
- * connect firebase's data
- *
- */
+
 @firebaseConnect([
     'flights'
 ])
@@ -38,22 +26,7 @@ export default class AboutPage extends Component {
 
     }
 
-
-
-    /**
-     * componentDidMount
-     *
-     * auth user by firebase
-     * if no auth, turn to login url and show LoginComponent
-     */
-    componentDidMount(){
-        let { firebase , params} = this.props;
-        // console.log('AboutPage', this.props);
-
-    }
-
     componentWillReceiveProps(nextProps){
-        // console.log('nextProps Home:',nextProps);
         let { isPhone } = this.state;
         if(isPhone != nextProps.isPhone){
             this.setState({
@@ -68,28 +41,26 @@ export default class AboutPage extends Component {
         )
     }
 
-
     render() {
-        var MyLayout = this.state.isPhone ? LayoutInner : Layout;
         return (
-            <LayoutInner title="使用说明" isPhone={this.state.isPhone} rightButtons={this.renderRightForLayout}>
+            <LayoutInner title="维护说明" isPhone={this.state.isPhone} rightButtons={this.renderRightForLayout}>
                 <div className="page-shell inner-page-shell">
                     <div className="panel-card">
                         <div className="panel-title">页面目标</div>
                         <p className="panel-text">
-                            把常见 AI 工具的用途、状态和适用场景统一展示，帮助团队更快做选型。
+                            统一沉淀用户资料、角色策略和安全规范，确保管理员与业务负责人在同一页面协作。
                         </p>
                     </div>
                     <div className="panel-card">
                         <div className="panel-title">建议维护方式</div>
                         <ul className="bullet-list">
-                            <li>按周更新工具状态与适用说明</li>
-                            <li>新增工具时补齐功能、定价和适用团队</li>
-                            <li>优先补充高频使用的对比工具</li>
+                            <li>按周检查待激活、待审批和停用中的账号状态</li>
+                            <li>按部门维护角色模板，避免重复分配权限</li>
+                            <li>为高权限角色强制开启 SSO、MFA 与操作审计</li>
                         </ul>
                     </div>
                     <div className="page-actions">
-                        <Link className="primary-link" to="/tools">查看工具管理页</Link>
+                        <Link className="primary-link" to="/users">查看用户管理页</Link>
                         <Link className="secondary-link" to="/">返回首页</Link>
                     </div>
                 </div>
@@ -97,4 +68,3 @@ export default class AboutPage extends Component {
         );
     }
 }
-

--- a/react-layout-router-demo/src/pages/home.page.js
+++ b/react-layout-router-demo/src/pages/home.page.js
@@ -2,23 +2,12 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import {
     firebaseConnect,
-    isLoaded,
-    isEmpty,
     dataToJS,
-    pathToJS,
 } from 'react-redux-firebase';
 import { Link } from 'react-router';
 
-/**
- * import libs: antd, material
- */
-
 import Layout from './layout';
-/**
- * initialize a Page Component named HomePage
- * connect firebase's data
- *
- */
+
 @firebaseConnect([
     'flights'
 ])
@@ -36,40 +25,12 @@ export default class HomePage extends Component {
     constructor(props){
         super(props);
 
-        /**
-         * bind some handle to self
-         */
         this.state = {
             isPhone: props.isPhone,
         }
     }
 
-
-    /**
-     * componentDidMount
-     *
-     * auth user by firebase
-     * if no auth, turn to login url and show LoginComponent
-     */
-    componentDidMount(){
-        console.log('Home', window.history.length);
-        let { firebase } = this.props;
-        // console.log('HomePage', this.props);
-        // dispatch({type:'SHOW_ORDER', data: true})
-        // console.log(this.props);
-        // firebase.logout();
-        // firebase.auth().onAuthStateChanged((user) => {
-        //     // console.log('is login：',user)
-        //     if (user) {
-        //     // User is signed in.
-        //     }else{
-        //         hashHistory.push('/login')
-        //     }
-        // });
-    }
-
     componentWillReceiveProps(nextProps){
-        // console.log('nextProps Home:',nextProps);
         let { isPhone } = this.state;
         if(isPhone != nextProps.isPhone){
             this.setState({
@@ -78,57 +39,54 @@ export default class HomePage extends Component {
         }
     }
 
-
-
     render() {
-
         return (
-            <Layout title="AI 工具工作台" isPhone={this.state.isPhone}>
+            <Layout title="用户管理工作台" isPhone={this.state.isPhone}>
                 <div className="page-shell">
                     <div className="page-hero">
                         <div className="page-hero-copy">
-                            <span className="page-badge">Tool Management</span>
-                            <h1>集中管理团队常用的 AI 工具</h1>
+                            <span className="page-badge">User Management</span>
+                            <h1>集中维护成员、权限与账号状态</h1>
                             <p>
-                                先把 AI 工具说明和对比能力整理起来，方便团队统一了解工具定位、
-                                适用场景与当前状态。
+                                以用户为中心统一查看组织成员、角色分配、激活状态和安全要求，
+                                帮助团队更快完成开通、调整和审计闭环。
                             </p>
                             <div className="page-actions">
-                                <Link className="primary-link" to="/tools">进入工具管理页</Link>
-                                <Link className="secondary-link" to="/about">查看使用说明</Link>
+                                <Link className="primary-link" to="/users">进入用户管理</Link>
+                                <Link className="secondary-link" to="/about">查看维护说明</Link>
                             </div>
                         </div>
                         <div className="hero-metrics">
                             <div className="metric-card">
-                                <strong>12</strong>
-                                <span>已整理工具</span>
+                                <strong>128</strong>
+                                <span>组织成员</span>
                             </div>
                             <div className="metric-card">
-                                <strong>4</strong>
-                                <span>优先推荐分类</span>
+                                <strong>16</strong>
+                                <span>角色模板</span>
                             </div>
                             <div className="metric-card">
-                                <strong>3</strong>
-                                <span>待补充说明</span>
+                                <strong>7</strong>
+                                <span>待审批申请</span>
                             </div>
                         </div>
                     </div>
 
                     <div className="content-grid">
                         <div className="panel-card">
-                            <div className="panel-title">当前整理重点</div>
+                            <div className="panel-title">当前管理重点</div>
                             <ul className="bullet-list">
-                                <li>AI 对比工具：收集、定位与推荐人群</li>
-                                <li>内容创作工具：快速生成、润色与翻译能力</li>
-                                <li>设计辅助工具：视觉稿、原型和素材产出</li>
+                                <li>统一成员信息入口，按团队与角色快速检索</li>
+                                <li>完善账号激活、停用与审批中的状态追踪</li>
+                                <li>补齐管理员、普通成员与访客的权限边界</li>
                             </ul>
                         </div>
                         <div className="panel-card">
-                            <div className="panel-title">推荐管理维度</div>
+                            <div className="panel-title">建议优先建设</div>
                             <ul className="bullet-list">
-                                <li>功能定位：工具能解决什么问题</li>
-                                <li>接入状态：已上线、测试中、规划中</li>
-                                <li>适用团队：产品、运营、研发、设计</li>
+                                <li>角色模板：减少重复授权配置</li>
+                                <li>安全校验：SSO、MFA 与异常登录提醒</li>
+                                <li>生命周期：入职、转岗、离职自动流转</li>
                             </ul>
                         </div>
                     </div>
@@ -137,4 +95,3 @@ export default class HomePage extends Component {
         );
     }
 }
-

--- a/react-layout-router-demo/src/pages/layout.js
+++ b/react-layout-router-demo/src/pages/layout.js
@@ -95,7 +95,7 @@ export default class Layout extends Component {
 
 
     addNewOrder(){
-        hashHistory.push('/tools');
+        hashHistory.push('/users');
     }
 
     renderAppBarRight(){
@@ -168,14 +168,14 @@ export default class Layout extends Component {
                             <div className="home-route-logo" style={{margin:0}}></div>
                         </div>
                         <div className="company-name">
-                            AI Tool Hub
+                            User Admin Hub
                         </div>
                         <ul className="link-list">
                             <li className="clearfix">
                                 <Link className="l nav-link" to="/">首页概览</Link>
                             </li>
                             <li className="clearfix">
-                                <Link className="l nav-link" to="/tools">工具管理</Link>
+                                <Link className="l nav-link" to="/users">用户管理</Link>
                                 <div className="tip r">12</div>
                             </li>
                             <li className="clearfix">
@@ -189,13 +189,13 @@ export default class Layout extends Component {
                         </ul>
                         <div className="sider-bottom">
                             <div className="link">
-                                <span className="">新增工具</span>
+                                <span className="">新增成员</span>
                             </div>
                             <div className="link">
-                                <span className="">状态维护</span>
+                                <span className="">权限策略</span>
                             </div>
                             <div className="link">
-                                <span className="">说明文档</span>
+                                <span className="">审计日志</span>
                             </div>
                         </div>
                     </div>

--- a/react-layout-router-demo/src/pages/other.page.js
+++ b/react-layout-router-demo/src/pages/other.page.js
@@ -1,25 +1,13 @@
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import {
     firebaseConnect,
-    isLoaded,
-    isEmpty,
     dataToJS,
-    pathToJS,
 } from 'react-redux-firebase';
 import { Link } from 'react-router';
 
-/**
- * import libs: antd, material
- */
 import LayoutInner from './layout-inner';
 
-/**
- * initialize a Page Component named HomePage
- * connect firebase's data
- *
- */
 @firebaseConnect([
     'flights'
 ])
@@ -29,49 +17,26 @@ import LayoutInner from './layout-inner';
     })
 )
 export default class OtherPage extends Component {
-    constructor(props){
-        super(props);
-
-
-    }
-
-
-
-    /**
-     * componentDidMount
-     *
-     * auth user by firebase
-     * if no auth, turn to login url and show LoginComponent
-     */
-    componentDidMount(){
-        let { firebase , params} = this.props;
-
-    }
-
     renderRightForLayout(){
         return (
             'zxczxc'
         )
     }
 
-
-
     render() {
-
-
         return (
-            <LayoutInner title="补充信息" rightButtons={this.renderRightForLayout}>
+            <LayoutInner title="扩展规划" rightButtons={this.renderRightForLayout}>
                 <div className="page-shell inner-page-shell">
                     <div className="panel-card">
                         <div className="panel-title">后续可扩展内容</div>
                         <ul className="bullet-list">
-                            <li>工具申请流程和权限管理</li>
-                            <li>工具使用反馈与评分</li>
-                            <li>团队共享 Prompt 和最佳实践</li>
+                            <li>成员批量导入导出与部门同步</li>
+                            <li>审批流、工单流与账号回收自动化</li>
+                            <li>登录日志、异常提醒与合规审计报表</li>
                         </ul>
                     </div>
                     <div className="page-actions">
-                        <Link className="primary-link" to="/tools">进入工具管理页</Link>
+                        <Link className="primary-link" to="/users">进入用户管理页</Link>
                         <Link className="secondary-link" to="/about">查看说明</Link>
                     </div>
                 </div>
@@ -80,4 +45,3 @@ export default class OtherPage extends Component {
         );
     }
 }
-

--- a/react-layout-router-demo/src/pages/tools.page.js
+++ b/react-layout-router-demo/src/pages/tools.page.js
@@ -1,50 +1,69 @@
 import React, { Component } from 'react';
 import Layout from './layout';
 
-const toolGroups = [
+const members = [
     {
-        name: 'ChatGPT',
-        category: '综合助手',
+        name: 'Lucien Chen',
+        role: '管理员',
         status: 'status-live',
-        statusText: '已接入',
-        description: '适合进行知识问答、写作辅助、需求整理和多轮头脑风暴。',
-        meta: ['内容创作', '方案拆解', '团队协作'],
-        highlights: ['统一 AI 工具说明入口', '可沉淀常见使用场景', '适合做团队默认推荐'],
+        statusText: '正常',
+        team: '产品团队',
+        email: 'lucien.chen@team.io',
+        tags: ['Owner', 'SSO', '高权限'],
+        highlights: ['负责组织配置与角色策略', '可审核新成员申请', '维护关键账号安全策略'],
     },
     {
-        name: 'Claude',
-        category: '长文理解',
+        name: 'Mia Zhou',
+        role: '运营经理',
+        status: 'status-live',
+        statusText: '正常',
+        team: '运营团队',
+        email: 'mia.zhou@team.io',
+        tags: ['Active', '内容运营', '最近登录 2h'],
+        highlights: ['管理运营成员分组', '可查看业务数据看板', '支持邀请外部协作者'],
+    },
+    {
+        name: 'Aron Li',
+        role: '访客',
         status: 'status-test',
-        statusText: '测试中',
-        description: '更适合长文本阅读、文档分析和较复杂的上下文处理场景。',
-        meta: ['长文总结', '策略分析', '知识库问答'],
-        highlights: ['适合复杂文档对比', '能补充内容分析场景', '推荐给产品与运营'],
+        statusText: '待激活',
+        team: '设计协作',
+        email: 'aron.li@agency.io',
+        tags: ['Invite', '只读权限', '外部成员'],
+        highlights: ['等待完成邮箱验证', '激活后自动加入设计项目组', '限制敏感配置与导出权限'],
     },
     {
-        name: 'Perplexity',
-        category: '检索问答',
-        status: 'status-live',
-        statusText: '已接入',
-        description: '强调联网检索与引用，适合快速调研、行业信息追踪和事实核验。',
-        meta: ['行业调研', '信息检索', '快速验证'],
-        highlights: ['适合做资讯类问题入口', '有助于补齐来源可信度', '便于对外信息收集'],
-    },
-    {
-        name: 'Midjourney',
-        category: '视觉生成',
+        name: 'Nina Wang',
+        role: '审计员',
         status: 'status-plan',
-        statusText: '规划中',
-        description: '用于概念图、海报灵感和视觉风格探索，适合设计前期提案。',
-        meta: ['视觉概念', '海报灵感', '品牌氛围'],
-        highlights: ['适合与设计流程结合', '优先补充使用规范', '建议后续增加案例库'],
+        statusText: '待审批',
+        team: '财务与合规',
+        email: 'nina.wang@team.io',
+        tags: ['审批中', '日志查看', '合规'],
+        highlights: ['申请访问操作日志', '需绑定 MFA 后启用账号', '上线后纳入季度审计流程'],
     },
 ];
 
-const comparisonRows = [
-    ['ChatGPT', '内容创作 / 办公辅助', '高', '运营、产品、研发', '默认推荐'],
-    ['Claude', '长文档理解 / 分析', '中', '产品、策略、研究', '适合复杂文档'],
-    ['Perplexity', '联网调研 / 引用核验', '高', '运营、市场、商务', '适合搜索型需求'],
-    ['Midjourney', '图片生成 / 灵感探索', '中', '设计、品牌', '待补充规范'],
+const permissionRows = [
+    ['管理员', '组织设置、角色配置、成员导入导出', '全部项目', 'MFA + 审批'],
+    ['业务负责人', '成员分组、资源分配、邀请成员', '所属团队', 'SSO'],
+    ['普通成员', '查看与编辑被授权内容', '授权项目', 'SSO / 邮箱'],
+    ['访客', '只读访问、评论、受限下载', '指定空间', '邮箱验证'],
+];
+
+const lifecycleSteps = [
+    {
+        title: '入职开通',
+        desc: '通过部门模板批量发放基础角色，缩短新成员开通时间。',
+    },
+    {
+        title: '权限调整',
+        desc: '根据岗位变化进行角色升级、团队迁移与敏感权限审批。',
+    },
+    {
+        title: '离职回收',
+        desc: '自动停用账号、移交资源并保留完整审计日志。',
+    },
 ];
 
 export default class ToolsPage extends Component {
@@ -64,17 +83,17 @@ export default class ToolsPage extends Component {
         }
     }
 
-    renderToolCard(item, index){
+    renderUserCard(item, index){
         return (
             <div className="tool-card" key={index}>
                 <div className="tool-card-header">
-                    <span className="tool-tag">{item.category}</span>
+                    <span className="tool-tag">{item.team}</span>
                     <span className={`status-badge ${item.status}`}>{item.statusText}</span>
                 </div>
                 <h3>{item.name}</h3>
-                <p>{item.description}</p>
+                <p>{item.role} · {item.email}</p>
                 <div className="tool-meta">
-                    {item.meta.map((text, metaIndex) => (
+                    {item.tags.map((text, metaIndex) => (
                         <span className="meta-pill" key={metaIndex}>{text}</span>
                     ))}
                 </div>
@@ -89,51 +108,50 @@ export default class ToolsPage extends Component {
 
     render() {
         return (
-            <Layout title="工具管理" isPhone={this.state.isPhone}>
+            <Layout title="用户管理" isPhone={this.state.isPhone}>
                 <div className="page-shell">
                     <div className="tool-toolbar">
                         <div>
-                            <h1 className="section-title">AI 工具管理页面</h1>
+                            <h1 className="section-title">用户管理中心</h1>
                             <p className="section-desc">
-                                统一整理团队正在使用和准备接入的 AI 工具，先覆盖工具说明、适用场景和对比信息，
-                                为后续权限管理、申请流程和案例沉淀打基础。
+                                把成员信息、角色权限、激活状态和生命周期管理集中到一个界面，
+                                方便团队快速完成开通、审批、停用与审计追踪。
                             </p>
                         </div>
                         <div className="toolbar-stats">
                             <div className="toolbar-chip">
-                                <strong>4</strong>
-                                <span>核心工具</span>
+                                <strong>128</strong>
+                                <span>总用户数</span>
                             </div>
                             <div className="toolbar-chip">
-                                <strong>3</strong>
-                                <span>管理维度</span>
+                                <strong>24</strong>
+                                <span>待处理变更</span>
                             </div>
                             <div className="toolbar-chip">
-                                <strong>1</strong>
-                                <span>优先对比页</span>
+                                <strong>98%</strong>
+                                <span>已绑定 SSO</span>
                             </div>
                         </div>
                     </div>
 
                     <div className="tool-grid">
-                        {toolGroups.map((item, index) => this.renderToolCard(item, index))}
+                        {members.map((item, index) => this.renderUserCard(item, index))}
                     </div>
 
                     <div className="panel-card" style={{marginBottom: 24}}>
-                        <div className="panel-title">工具对比总览</div>
+                        <div className="panel-title">角色与权限矩阵</div>
                         <div className="comparison-table">
                             <table>
                                 <thead>
                                     <tr>
-                                        <th>工具</th>
-                                        <th>定位</th>
-                                        <th>上手难度</th>
-                                        <th>推荐团队</th>
-                                        <th>备注</th>
+                                        <th>角色</th>
+                                        <th>核心权限</th>
+                                        <th>可访问范围</th>
+                                        <th>安全要求</th>
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {comparisonRows.map((row, index) => (
+                                    {permissionRows.map((row, index) => (
                                         <tr key={index}>
                                             {row.map((col, columnIndex) => (
                                                 <td key={columnIndex}>{col}</td>
@@ -146,18 +164,12 @@ export default class ToolsPage extends Component {
                     </div>
 
                     <div className="roadmap-grid">
-                        <div className="roadmap-card">
-                            <h4>阶段一：说明整理</h4>
-                            <p>先把 AI 工具的名称、定位、适用场景和状态维护起来，形成统一信息入口。</p>
-                        </div>
-                        <div className="roadmap-card">
-                            <h4>阶段二：对比视图</h4>
-                            <p>把高频工具放入同一视图比较，突出推荐人群、优缺点和接入优先级。</p>
-                        </div>
-                        <div className="roadmap-card">
-                            <h4>阶段三：流程扩展</h4>
-                            <p>后续可继续加入申请、审批、反馈和使用案例，让工具管理更完整。</p>
-                        </div>
+                        {lifecycleSteps.map((item, index) => (
+                            <div className="roadmap-card" key={index}>
+                                <h4>{item.title}</h4>
+                                <p>{item.desc}</p>
+                            </div>
+                        ))}
                     </div>
                 </div>
             </Layout>


### PR DESCRIPTION
### Motivation
- Convert the existing AI tool-management demo into a focused user-management experience so the demo can be used to prototype member, role and lifecycle UIs and copy. 
- Surface a dedicated entry point and navigation for user administration so the app can demonstrate user flows like onboarding, role changes and deprovisioning.

### Description
- Added a `/users` route and wired the layout's primary actions and sidebar to navigate to `/users` by default, and updated the document title to `User Admin Hub` via `react-layout-router-demo/src/index.tmpl.html` and `react-layout-router-demo/src/config/router.js`.
- Reworked the original `tools.page` content into a user-management backing component (kept as `tools.page.js`) and replaced AI-tool data with member cards, `permissionRows` and `lifecycleSteps` to represent roles, permissions and lifecycle stages in `react-layout-router-demo/src/pages/tools.page.js`.
- Updated the home, about (maintenance) and other (roadmap/extension) pages to reflect user-management goals and links in `react-layout-router-demo/src/pages/home.page.js`, `react-layout-router-demo/src/pages/about.page.js`, and `react-layout-router-demo/src/pages/other.page.js`.
- Rethemed the layout strings and quick-add action to reference users (e.g. `新增成员`, `权限策略`, `审计日志`) and changed the quick action to push to `/users` in `react-layout-router-demo/src/pages/layout.js`.

### Testing
- Ran a repository search to confirm the new labels and routes with `rg -n "用户管理|User Management|/users|维护说明|扩展规划|User Admin Hub"` which returned matches in the modified files and succeeded. 
- Ran a sanity check script with `node -e "const fs=require('fs');[...]"` to validate key page files export components, which printed `sanity ok` and succeeded. 
- Attempted a production build with `npm run build`, which failed in this environment because project dependencies are not installed and `webpack` was not found (build error expected in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd0a51a5988329bd290d21df1100d2)